### PR TITLE
Fix device type handling in risk-averse optimize step

### DIFF
--- a/deepopt/__init__.py
+++ b/deepopt/__init__.py
@@ -2,4 +2,4 @@
 This module is necessary for having the DeepOpt library be importable.
 It also contains version tracking for the DeepOpt library.
 """
-__version__ = "0.2.6"
+__version__ = "0.2.7"

--- a/deepopt/models.py
+++ b/deepopt/models.py
@@ -643,7 +643,8 @@ class DeepoptBaseModel(ABC):
 
         if risk_measure:
             assert acq_method != "MaxValEntropy", "Risk measure not yet supported for MaxValueEntropy acquisition"
-            x_stddev_scaled = x_stddev.to(self.bounds.device) / (self.bounds[1] - self.bounds[0])
+            x_stddev = torch.tensor(x_stddev,dtype=torch.float,device=self.bounds.device)
+            x_stddev_scaled = x_stddev / (self.bounds[1] - self.bounds[0])
             bounds_scaled = torch.tensor(self.input_dim * [[0, 1]],dtype=torch.float).T
             if self.multi_fidelity:
                 x_stddev_scaled[-1] = 0


### PR DESCRIPTION
Fix device type handling (numpy/torch) when using risk-averse optimization